### PR TITLE
Fix wrong balance check

### DIFF
--- a/.github/workflows/hardhat-tests.yml
+++ b/.github/workflows/hardhat-tests.yml
@@ -14,7 +14,6 @@ on:
   workflow_dispatch:
 
 env:
-  PRIVATE_KEY: ${{secrets.PRIVATE_KEY}}
   RINKEBY_API_URL: https://eth-rinkeby.alchemyapi.io/v2/
   MAINNET_API_URL: https://eth-mainnet.alchemyapi.io/v2/
   ETHERSCAN_API_KEY: 9B8CYSW8SA1A2XP4HD6Q6TVPCNA8HYJVZA

--- a/smart-contracts/contracts/BurnMyWallet.sol
+++ b/smart-contracts/contracts/BurnMyWallet.sol
@@ -27,7 +27,7 @@ contract BurnMyWallet is ERC721, Ownable {
     */
     function mint() public {
         require(
-            address(this).balance == 0,
+            balanceOf(msg.sender) == 0,
             "Err: only one BURN token may be minted per account"
         );
         uint256 tokenId = _tokenIdCounter.current();

--- a/smart-contracts/contracts/BurnMyWallet.sol
+++ b/smart-contracts/contracts/BurnMyWallet.sol
@@ -51,6 +51,6 @@ contract BurnMyWallet is ERC721, Ownable {
     prevent a user from burning a token
     */
     function _burn(uint256 tokenId) internal override(ERC721) {
-        require(true == false, "Err: cannot burn the BURN token");
+        revert("Err: cannot burn the BURN token");
     }
 }

--- a/smart-contracts/hardhat.config.js
+++ b/smart-contracts/hardhat.config.js
@@ -13,12 +13,24 @@ const {
   RINKEBY_API_URL,
   MAINNET_API_URL,
   POLYGON_API_URL,
-  PRIVATE_KEY,
   ETHERSCAN_API_KEY,
   POLYGONSCAN_API_KEY,
   CONTRACT_ADDRESS,
   ROYALTY_RECEIVER_ADDR,
 } = process.env;
+
+// THIS IS A PUBLICLY KNOWN (HARDHAT) PRIVATE KEY. 
+// DO NOT USE THIS IN PRODUCTION OR SEND ANY FUNDS TO THE ASSOCIATED ADDRESS
+const BACKUP_PRIVATE_KEY = "f2f48ee19680706196e2e339e5da3491186e0c4c5030670656b0e0164837257d";
+
+let PRIVATE_KEY;
+if(process.env.PRIVATE_KEY) {
+    PRIVATE_KEY = process.env.PRIVATE_KEY;
+} else {
+    console.log("Using backup private key");
+    PRIVATE_KEY = BACKUP_PRIVATE_KEY;
+}
+
 
 task("accounts", "Prints the list of accounts", async (taskArgs, hre) => {
   const accounts = await hre.ethers.getSigners();
@@ -45,14 +57,6 @@ module.exports = {
     },
   },
   networks: {
-    hardhat: {
-      accounts: [
-        {
-          privateKey: `0x${PRIVATE_KEY}`,
-          balance: "2873948027343750000000000000000000",
-        },
-      ],
-    },
     rinkeby: {
       url: RINKEBY_API_URL ?? "",
       accounts: [`0x${PRIVATE_KEY}`],

--- a/smart-contracts/hardhat.config.js
+++ b/smart-contracts/hardhat.config.js
@@ -19,18 +19,18 @@ const {
   ROYALTY_RECEIVER_ADDR,
 } = process.env;
 
-// THIS IS A PUBLICLY KNOWN (HARDHAT) PRIVATE KEY. 
+// THIS IS A PUBLICLY KNOWN (HARDHAT) PRIVATE KEY.
 // DO NOT USE THIS IN PRODUCTION OR SEND ANY FUNDS TO THE ASSOCIATED ADDRESS
-const BACKUP_PRIVATE_KEY = "f2f48ee19680706196e2e339e5da3491186e0c4c5030670656b0e0164837257d";
+const BACKUP_PRIVATE_KEY =
+  "f2f48ee19680706196e2e339e5da3491186e0c4c5030670656b0e0164837257d";
 
 let PRIVATE_KEY;
-if(process.env.PRIVATE_KEY) {
-    PRIVATE_KEY = process.env.PRIVATE_KEY;
+if (process.env.PRIVATE_KEY) {
+  PRIVATE_KEY = process.env.PRIVATE_KEY;
 } else {
-    console.log("Using backup private key");
-    PRIVATE_KEY = BACKUP_PRIVATE_KEY;
+  console.log("Using backup private key");
+  PRIVATE_KEY = BACKUP_PRIVATE_KEY;
 }
-
 
 task("accounts", "Prints the list of accounts", async (taskArgs, hre) => {
   const accounts = await hre.ethers.getSigners();
@@ -57,6 +57,14 @@ module.exports = {
     },
   },
   networks: {
+    hardhat: {
+      accounts: [
+        {
+          privateKey: PRIVATE_KEY,
+          balance: "10000000000000000000000",
+        },
+      ],
+    },
     rinkeby: {
       url: RINKEBY_API_URL ?? "",
       accounts: [`0x${PRIVATE_KEY}`],

--- a/smart-contracts/test/basic-test.js
+++ b/smart-contracts/test/basic-test.js
@@ -28,13 +28,6 @@ describe("Basic Burn My Wallet Tests", function () {
     await burn.mint();
     expect(await burn.balanceOf(owner.address)).to.equal(1);
 
-    const burnHash = await burn.mint();
-    expect(burnHash.hash).to.not.be.NaN;
-
-    expect(await burn.balanceOf(owner.address)).to.equal(2);
-
-    console.log(await burn.balanceOf(owner.address));
-
     await expect(
       burn.mint()
     ).to.be.revertedWith("Err: only one BURN token may be minted per account");

--- a/smart-contracts/test/basic-test.js
+++ b/smart-contracts/test/basic-test.js
@@ -4,40 +4,52 @@ var Web3 = require("web3");
 
 // "Web3.providers.givenProvider" will be set if in an Ethereum supported browser.
 var web3 = new Web3(
-  Web3.givenProvider || "ws://some.local-or-remote.node:8546"
+    Web3.givenProvider || "ws://some.local-or-remote.node:8546"
 );
 
 describe("Basic Burn My Wallet Tests", function () {
-  var burn;
-  var owner, addr1, addr2;
+    var burn;
+    var owner, addr1, addr2;
 
-  beforeEach(async function () {
-    const BURN = await ethers.getContractFactory("BurnMyWallet");
-    burn = await BURN.deploy();
-    await burn.deployed();
+    beforeEach(async function () {
+        const BURN = await ethers.getContractFactory("BurnMyWallet");
+        burn = await BURN.deploy();
+        await burn.deployed();
 
-    [owner, addr1, addr2] = await ethers.getSigners();
-  });
+        [owner, addr1, addr2] = await ethers.getSigners();
+    });
 
-  it("should allow user to mint BURN token", async function () {
-    await burn.mint();
-    expect(await burn.balanceOf(owner.address)).to.equal(1);
-  });
+    it("should allow user to mint BURN token", async function () {
+        await burn.mint();
+        expect(await burn.balanceOf(owner.address)).to.equal(1);
+    });
 
-  it("should not allow user to mint multiple BURN tokens", async function () {
-    await burn.mint();
-    expect(await burn.balanceOf(owner.address)).to.equal(1);
+    it("should not allow user to mint multiple BURN tokens", async function () {
+        await burn.mint();
+        expect(await burn.balanceOf(owner.address)).to.equal(1);
 
-    await expect(
-      burn.mint()
-    ).to.be.revertedWith("Err: only one BURN token may be minted per account");
-  });
+        await expect(burn.mint()).to.be.revertedWith(
+            "Err: only one BURN token may be minted per account"
+        );
+    });
 
-  it("should not allow user to send BURN tokens", async function () {
-    await burn.mint();
-    expect(await burn.balanceOf(owner.address)).to.equal(1);
-    await expect(
-      burn["safeTransferFrom(address,address,uint256)"](owner.address, owner.address, 0)
-    ).to.be.revertedWith("Err: token is SOUL BOUND");
-  });
+    it("should not allow user to send BURN tokens using safeTransferFrom", async function () {
+        await burn.mint();
+        expect(await burn.balanceOf(owner.address)).to.equal(1);
+        await expect(
+            burn["safeTransferFrom(address,address,uint256)"](
+                owner.address,
+                addr1.address,
+                0
+            )
+        ).to.be.revertedWith("Err: token is SOUL BOUND");
+    });
+
+    it("should not allow user to send BURN tokens using transfer", async function () {
+        await burn.mint();
+        expect(await burn.balanceOf(owner.address)).to.equal(1);
+        await expect(
+            burn.transferFrom(owner.address, addr1.address, 0)
+        ).to.be.revertedWith("Err: token is SOUL BOUND");
+    });
 });


### PR DESCRIPTION
You're checking the wrong thing when trying to make sure that any user can mint only one BURN token.

Instead of checking the users balance of `BURN` token you are checking the **eth** balance of the contract.
This not only renders the check ineffective, **but also allows anyone to break the contract by sending eth to it, after which no user will be able to mint new BURN tokens anymore**.

Even though you have no `receive` fallback method, that check can be circumvented using a `selfdestruct` opcode from another contract.